### PR TITLE
Fixed word splitting in fallback and completion modes

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -44,7 +44,8 @@ _up() {
 	local p="$(dirname "$PWD")"
 	local w="${COMP_WORDS[COMP_CWORD]}"
 
-	COMPREPLY=( $(IFS='/' compgen -S/ -W "$p" -- "$w") )
+	COMPREPLY=()
+	while IFS='' read -r line; do COMPREPLY+=("$line"); done < <(IFS='/' compgen -S/ -W "$p" -- "$w")
 }
 
 up() {

--- a/up.sh
+++ b/up.sh
@@ -44,7 +44,7 @@ _up() {
 	local p="$(dirname "$PWD")"
 	local w="${COMP_WORDS[COMP_CWORD]}"
 
-	COMPREPLY=( $(IFS=';' compgen -S/ -W "${p//\//;}" -- "$w") )
+	COMPREPLY=( $(IFS='/' compgen -S/ -W "$p" -- "$w") )
 }
 
 up() {

--- a/up.sh
+++ b/up.sh
@@ -41,7 +41,7 @@ __upnum() {
 }
 
 _up() {
-	local p="$(dirname $PWD)"
+	local p="$(dirname "$PWD")"
 	local w="${COMP_WORDS[COMP_CWORD]}"
 
 	COMPREPLY=( $(IFS=';' compgen -S/ -W "${p//\//;}" -- "$w") )
@@ -71,8 +71,8 @@ up() {
 	fi
 
 	# fallback
-	if [[ $1 == - || -d $1 ]]; then
-		cd $1
+	if [[ "$1" == - || -d "$1" ]]; then
+		cd "$1"
 		return
 	fi
 


### PR DESCRIPTION
I'm not happy with `COMPREPLY` array filling solution, but it works with both bash and zsh on my system.